### PR TITLE
add support for a local-overwrite in .php_cs

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -12,6 +12,11 @@ $finder = Symfony\CS\Finder\DefaultFinder::create()
     ->in(__DIR__)
 ;
 
+// Load a local config-file when existing
+if (file_exists('local.php_cs')) {
+    require 'local.php_cs';
+}
+
 return Symfony\CS\Config\Config::create()
     ->addCustomFixer(new Decoupling\Fixer\ShortArraySyntaxFixer)
     ->fixers(


### PR DESCRIPTION
This allows to do local overwrites, for the IDE or experimental folder.
Or when using a local library-folder for none composer manageable stuff.

local.php_cs can use the `$finder` to add additional excluding.

``` php
<?php

$finder
    ->exclude('.idea')
;
```
